### PR TITLE
Updated bin/install.sh and srv/isc-agent/settings.py

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1827,7 +1827,11 @@ drun 'cat /etc/dshield.ini'
 
 dlog "installing cowrie"
 
-# step 1 (Install OS dependencies): done
+# step 1 (Install OS dependencies)
+
+# support for ubuntu server 22.04.2 LTS
+dlog "(re)installing python attrs package"
+run "pip3 install --ignore-installed attrs"
 
 # step 2 (Create a user account)
 dlog "checking if cowrie OS user already exists"
@@ -2004,6 +2008,9 @@ find /etc/rc?.d -name '*cowrie*' -delete
 run 'systemctl daemon-reload'
 run 'systemctl enable cowrie.service'
 
+dlog 'deactivate cowrie venv'
+run 'deactivate'
+
 ###########################################################
 ## Installation of isc-agent
 ###########################################################
@@ -2012,22 +2019,26 @@ outlog "Installing ISC-Agent"
 dlog "installing ISC-Agent"
 
 run "mkdir -p ${ISC_AGENT_DIR}"
-
 do_copy $progdir/../srv/isc-agent ${ISC_AGENT_DIR}/../
 do_copy $progdir/../lib/systemd/system/isc-agent.service ${systemdpref}/lib/systemd/system/ 644
 run "chmod +x /srv/isc-agent/bin/isc-agent"
 run "mkdir -m 0700 /srv/isc-agent/run"
-run "deactivate"
 OLDPWD=$PWD
 cd ${ISC_AGENT_DIR}
+dlog "activate isc-agent venv"
+run "source /srv/isc-agent/.venv/bin/activate"
 run "pip3 install --upgrade pip"
 run "pip3 install pipenv"
+run "pip3 install --ignore-installed -r requirements.txt --prefix /srv/isc-agent/.venv"
 run "pipenv lock"
 run "PIPENV_IGNORE_VIRTUALENVS=1 PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy"
 run "systemctl daemon-reload"
 run "systemctl enable isc-agent.service"
 [ "$ID" != "opensuse" ] && run "systemctl enable systemd-networkd.service systemd-networkd-wait-online.service"
 cd $OLDPWD
+
+dlog "deactivate isc-agent venv"
+run "deactivate"
 
 ###########################################################
 ## Copying further system files
@@ -2191,7 +2202,17 @@ clear
 if [ ${GENCERT} -eq 1 ]; then
   dlog "generating new CERTs using ./makecert.sh"
   ./makecert.sh
+  dlog "moving certs to /srv/log/isc-agent"
+  run "mv ~/dshield/etc/CA/keys/honeypot.key /srv/log/isc-agent/honeypot.key"
+  run "mv ~/dshield/etc/CA/certs/honeypot.crt /srv/log/isc-agent/honeypot.crt"
+
+  dlog "updating /etc/dshield.ini"
+  run 'echo "tlskey=/srv/log/isc-agent/honeypot.key" >> /etc/dshield.ini'
+  run 'echo "tlscert=/srv/log/isc-agent/honeypot.crt" >> /etc/dshield.ini'
 fi
+
+
+
 
 #
 # creating PID directory

--- a/srv/isc-agent/settings.py
+++ b/srv/isc-agent/settings.py
@@ -91,8 +91,8 @@ DATABASE_SESSION = Session(DATABASE_ENGINE)
 
 # SSL certification key and certificate
 
-PRIVATE_KEY = config.get('isc-agent', 'tlskey', fallback='/srv/isc-agent/honeypot.key')
-CERT_KEY = config.get('isc-agent', 'tlscert', fallback='/srv/isc-agent/honeypot.crt')
+PRIVATE_KEY = config.get('iscagent', 'tlskey', fallback='/srv/isc-agent/honeypot.key')
+CERT_KEY = config.get('iscagent', 'tlscert', fallback='/srv/isc-agent/honeypot.crt')
 
 # PLUGINS
 # Read from /etc/dshield.ini file


### PR DESCRIPTION
Updated settings.py to be compatible with /etc/dshield.ini
Updated install.sh to install python attrs globally for ubuntu server 22.04.2 lts support
Updated install.sh to copy certs to /srv/isc-agent for settings.py to detect